### PR TITLE
Add custom 404 redirect script

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,13 +8,6 @@
     <script src="https://kit.fontawesome.com/6d51c26809.js" crossorigin="anonymous"></script>
     <title>Jam Lab</title>
 
-    <!-- favicon -->
-    <link rel="icon" type=”image/svg+xml” href="/favicon/green-grid-144-168-192.svg">
-    <link rel="alternate icon" type="image/png" href="/favicon/green-grid-144-168-192-512x512.png">
-    <link rel="apple-touch-icon" href="/favicon/green-grid-144-168-192-180x180.png">
-    <link rel="manifest" href="/favicon/site.webmanifest">
-    <meta name="theme-color" content="#000000">
-
     <!-- Start Single Page Apps for GitHub Pages -->
     <script type="text/javascript">
       // Single Page Apps for GitHub Pages

--- a/index.html
+++ b/index.html
@@ -7,6 +7,39 @@
     <link href="/dist/styles.css" rel="stylesheet">
     <script src="https://kit.fontawesome.com/6d51c26809.js" crossorigin="anonymous"></script>
     <title>Jam Lab</title>
+
+    <!-- favicon -->
+    <link rel="icon" type=”image/svg+xml” href="/favicon/green-grid-144-168-192.svg">
+    <link rel="alternate icon" type="image/png" href="/favicon/green-grid-144-168-192-512x512.png">
+    <link rel="apple-touch-icon" href="/favicon/green-grid-144-168-192-180x180.png">
+    <link rel="manifest" href="/favicon/site.webmanifest">
+    <meta name="theme-color" content="#000000">
+
+    <!-- Start Single Page Apps for GitHub Pages -->
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script checks to see if a redirect is present in the query string,
+      // converts it back into the correct url and adds it to the
+      // browser's history using window.history.replaceState(...),
+      // which won't cause the browser to attempt to load the new url.
+      // When the single page app is loaded further down in this file,
+      // the correct url will be waiting in the browser's history for
+      // the single page app to route accordingly.
+      (function(l) {
+        if (l.search[1] === '/' ) {
+          var decoded = l.search.slice(1).split('&').map(function(s) { 
+            return s.replace(/~and~/g, '&')
+          }).join('?');
+          window.history.replaceState(null, null,
+              l.pathname.slice(0, -1) + decoded + l.hash
+          );
+        }
+      }(window.location))
+    </script>
+    <!-- End Single Page Apps for GitHub Pages -->
+     
   </head>
   <body>
     <div id="root"></div>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,43 @@
+<!-- This is a hack to defer routing to client side routing when hosting this as a SPA.  --> 
+<!-- See https://github.com/rafgraph/spa-github-pages for more information. -->
+ 
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Not Found</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (it is currently > 512 bytes)
+
+      // If you're creating a Project Pages site and NOT using a custom domain,
+      // then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+      // This way the code will only replace the route part of the path, and not
+      // the real directory in which the app resides, for example:
+      // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+      // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+      // Otherwise, leave pathSegmentsToKeep as 0.
+      var pathSegmentsToKeep = 0;
+
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@
   --color-jam-dark: #210535;
   --color-jam-primary: #c874b2;
   --color-jam-bg: #610f9b;
-  --color-jam-surface: #C874B2;
+  --color-jam-surface: #c874b2;
 }
 
 @layer base {

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -20,7 +20,7 @@ export default function Home() {
         });
     };
     fetchUserProfile();
-  }, [userProfileP]);
+  }, []);
   //TODO: Add a way to log out via UI
   return (
     <>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+    "rewrites": [
+      { "source": "/(.*)", "destination": "/index.html" }
+    ]
+  }


### PR DESCRIPTION
## Why is this needed?
Single Page Applications (SPAs) rely on client-side routing, meaning routes like `/login` or `/auth` are handled by JavaScript. However, when a user refreshes or directly accesses a route, the browser requests that path from the server. Since static file hosting (e.g., GitHub Pages, Vercel) only serves the files in dist/ (which typically includes just index.html), this results in a 404 Not Found error.

This was particularly a problem when integrating with Spotify oauth API which redirects to `/auth`

## How does this fix it?
This PR adds a 404.html file with a redirect script that automatically routes users back to index.html while preserving the original path. This ensures the client-side router can properly handle navigation, preventing broken links on refresh or direct access to deep routes.
This is more sanely explained here -> https://github.com/rafgraph/spa-github-pages#usage-instructions